### PR TITLE
chore: Lowercase OCI reference before pushing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,9 +66,11 @@ runs:
     - name: Push the Wasm binary to the registry
       shell: bash
       if: ${{ inputs.worlds != '*' }}
+      env:
+        INPUT_OCI_REF_WITHOUT_TAG: ${{ inputs.oci-reference-without-tag }}
       run: |
         set -ex
-        wkg oci push ${{ inputs.oci-reference-without-tag }}:${{ inputs.version }} ${{ inputs.file }}\
+        wkg oci push "${INPUT_OCI_REF_WITHOUT_TAG,,}:${{ inputs.version }}" ${{ inputs.file }}\
           --annotation "org.opencontainers.image.description"="${{ inputs.description }}" \
           --annotation "org.opencontainers.image.source"="${{ inputs.source }}" \
           --annotation "org.opencontainers.image.url"="${{ inputs.homepage }}" \


### PR DESCRIPTION
Motivated by https://github.com/bytecodealliance/wasm-pkg-tools/issues/134.

This uses bash parameter expansion with the `,,` operator to lowercase the entire input.