### PR TITLE
Wire `wkg` input through to the install step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,9 +53,15 @@ runs:
     # Install action dependencies
     - name: Setup `wkg`
       shell: bash
+      env:
+        WKG_VERSION: ${{ inputs.wkg }}
       run: |
         set -ex
-        cargo binstall wkg
+        if [ -n "$WKG_VERSION" ]; then
+          cargo binstall "wkg@$WKG_VERSION"
+        else
+          cargo binstall wkg
+        fi
 
     # Run the action
     - name: Push the Wasm binary to the registry


### PR DESCRIPTION
## Summary                                                                                                                                                                                                     
                  
The `wkg` input is declared but never referenced, so `cargo binstall wkg` always installs latest regardless of what callers pass in `with:`.

## Why this matters

wkg's validation and encoding can change across versions, so the push-side version needs to match the build-side. 

Concretely, wkg 0.14 tightened kebab-case validation and now rejects [async] extern names (e.g. wasi:http's [async]handle), so an artifact built with wkg 0.13 and pushed via this action (which pulls latest) ends up unfetchable by 0.13 consumers.

Pinning the input is the fix.